### PR TITLE
feat: add tools utility and improve tool handling

### DIFF
--- a/.changeset/young-berries-share.md
+++ b/.changeset/young-berries-share.md
@@ -1,0 +1,12 @@
+---
+"terminal-agent": minor
+"@mrck-labs/grid-workflows": minor
+"express-test": minor
+"nextjs-test": minor
+"@mrck-labs/grid-agents": minor
+"hono-test": minor
+"@mrck-labs/grid-tools": minor
+"@mrck-labs/grid-core": minor
+---
+
+changes in how the tools passing looks like

--- a/packages/core/src/factories/agent-config.schemas.ts
+++ b/packages/core/src/factories/agent-config.schemas.ts
@@ -95,7 +95,7 @@ export const AgentConfigSchema = z.object({
   behavior: AgentBehaviorSchema.default({}),
 
   // Tools configuration
-  tools: AgentToolsSchema.default({ builtin: [] }),
+  tools: AgentToolsSchema.default({ builtin: {} }),
 
   // Hooks for custom logic
   hooks: AgentHooksSchema.optional(),

--- a/packages/core/src/factories/configurable-agent.factory.ts
+++ b/packages/core/src/factories/configurable-agent.factory.ts
@@ -94,6 +94,9 @@ export const createConfigurableAgent = ({
     // TODO: Adapt builtin and agent tools
   };
 
+  console.log("These are available tools");
+  console.log(availableTools);
+
   let sendUpdate: (data: ProgressMessage) => Promise<void> = async (data) => {
     console.log("sendUpdate", data);
   };

--- a/packages/core/src/services/base.llm.service.ts
+++ b/packages/core/src/services/base.llm.service.ts
@@ -30,19 +30,22 @@ export const baseLLMService = (
     const {
       model = defaultModel,
       messages,
-      tools = {},
+      tools = undefined,
       temperature = 0.1,
       maxOutputTokens,
       responseFormat,
       traceContext,
     } = options;
 
+    console.log("[baseLLMService:runLLM] - tools");
+    console.log(tools);
+
     const result = await generateText({
       model: openai(model),
       messages: messages as ModelMessage[],
       temperature,
       maxOutputTokens,
-      tools: tools,
+      tools,
       stopWhen:
         toolExecutionMode === "custom" ? stepCountIs(1) : stepCountIs(12),
     });

--- a/packages/tools/src/index.ts
+++ b/packages/tools/src/index.ts
@@ -17,6 +17,7 @@ export { delayTool } from "./tools/delay.tool";
 export { hashTool } from "./tools/hash.tool";
 export { dataConverterTool } from "./tools/data-converter.tool";
 export { createImageTool } from "./tools/create-image.tool";
+export { getTools } from "./tools/get-tool";
 
 // Export all tools as a collection for convenience
 import { calculatorTool } from "./tools/calculator.tool";

--- a/packages/tools/src/tools/get-tool.ts
+++ b/packages/tools/src/tools/get-tool.ts
@@ -5,7 +5,7 @@ export const getTools = ({
   executionType = "custom",
   tools,
 }: {
-  executionType: "vercel-native" | "custom";
+  executionType?: "vercel-native" | "custom";
   tools: GridTool[];
 }) => {
   const availableTools: ToolSet = tools.reduce((acc, tool) => {

--- a/packages/tools/src/tools/get-tool.ts
+++ b/packages/tools/src/tools/get-tool.ts
@@ -1,0 +1,22 @@
+import type { GridTool } from "../types";
+import type { ToolSet } from "ai";
+
+export const getTools = ({
+  executionType = "custom",
+  tools,
+}: {
+  executionType: "vercel-native" | "custom";
+  tools: GridTool[];
+}) => {
+  const availableTools: ToolSet = tools.reduce((acc, tool) => {
+    return {
+      ...acc,
+      [tool.definition.name]:
+        executionType === "vercel-native"
+          ? tool.withExecute
+          : tool.withoutExecute,
+    };
+  }, {} as ToolSet);
+
+  return availableTools;
+};


### PR DESCRIPTION
- Added getTools() utility to convert GridTool[] to ToolSet format
- Supports both 'vercel-native' and 'custom' execution modes
- Returns tools with or without execute functions based on mode
- Added debug logging to baseLLMService for tool inspection
- Fixed tools parameter to be undefined instead of empty object when not provided
- Export getTools from tools package index

This improves tool handling flexibility and debugging capabilities.